### PR TITLE
Make industrial furnace optional

### DIFF
--- a/OD27_5dim_core/settings-updates.lua
+++ b/OD27_5dim_core/settings-updates.lua
@@ -317,6 +317,23 @@ if mods["OD27_5dim_infiniteresearch"] then
     )
 end
 
+if mods["OD27_5dim_resources"] then
+    --order f for resources
+    data:extend(
+        {
+            {
+                type = "bool-setting",
+                name = "5d-industrial-furnace",
+                order = "fa",
+                setting_type = "startup",
+                default_value = true,
+                per_user = false,
+                localised_name = "[5Dim's New Resources] Add Industrial furnace"
+            },
+        }
+    )
+end
+
 if mods["OD27_5dim_vehicle"] and mods["OD27_5dim_equipment"] then
     --order z for misc
     data:extend(

--- a/OD27_5dim_resources/data.lua
+++ b/OD27_5dim_resources/data.lua
@@ -13,11 +13,15 @@ require("prototypes.gen-masher")
 require("prototypes.gen-electric-furnace")
 
 --Furnace
-require("prototypes.industrial-furnace")
-require("prototypes.industrial-recipes")
+if settings.startup["5d-industrial-furnace"].value then
+    require("prototypes.industrial-furnace")
+    require("prototypes.industrial-recipes")
+end
 
 --Recipe
 require("prototypes.recipe-category")
 
 --Tech
-require("prototypes.tech")
+if settings.startup["5d-industrial-furnace"].value then
+    require("prototypes.tech")
+end


### PR DESCRIPTION
K2/SE also has an industrial furnace and we don't want to remove it again after it has been added (including the recipes).